### PR TITLE
fix rex of my-font-lock-brace-face matching backslash

### DIFF
--- a/src/chezscheme-font-lock.el
+++ b/src/chezscheme-font-lock.el
@@ -616,7 +616,7 @@
      1 font-lock-type-face)
 
     ;; Braces.
-    ("\\([\\{\\}]\\)"
+    ("\\([{}]\\)"
      (1 my-font-lock-brace-face))
 
     ;;This does numeric bytevectors.


### PR DESCRIPTION
this commit is related to symbols like \x41; 